### PR TITLE
add visa as brand name

### DIFF
--- a/lib/data/brands.yaml
+++ b/lib/data/brands.yaml
@@ -6,6 +6,8 @@
     - 16
     :prefixes:
     - '4'
+  :options:
+    :brand_name: Visa
 :mastercard:
   :rules:
   - :length:


### PR DESCRIPTION
Just saw that Visa was missing as a brand name and added it.