### PR TITLE
Bump activemodel and activesupport versions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+# 3.5.1
+   * Bump activemodel and activesupport versions
+
 # 3.5.0
    * Unionpay and Maestro range updates, PR #88
    * Hipercard range updates , PR #79

--- a/credit_card_validations.gemspec
+++ b/credit_card_validations.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{A ruby gem for validating credit card numbers}
   gem.summary       = "gem should be used for credit card numbers validation, card brands detections, luhn checks"
   gem.homepage      = "http://fivell.github.io/credit_card_validations/"
-  gem.license     = "MIT"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
@@ -19,8 +19,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
 
-  gem.add_dependency "activemodel", ">= 3", "<= 6"
-  gem.add_dependency "activesupport", ">= 3", "<= 6"
+  gem.add_dependency "activemodel", ">= 3", "<= 6.1"
+  gem.add_dependency "activesupport", ">= 3", "<= 6.1"
 
 
   gem.add_development_dependency "mocha", '1.1.0'

--- a/lib/credit_card_validations/version.rb
+++ b/lib/credit_card_validations/version.rb
@@ -1,3 +1,3 @@
 module CreditCardValidations
-  VERSION = '3.5.0'
+  VERSION = '3.5.1'
 end


### PR DESCRIPTION
Bump activemodel and activesupport versions to support Rails 6.0.1 upgrade

Fixes #96 